### PR TITLE
Respect when opts.grid_save and/or opts.samples_save are set to false.

### DIFF
--- a/test_my_prompt/scripts/test_my_prompt_custom_script.py
+++ b/test_my_prompt/scripts/test_my_prompt_custom_script.py
@@ -74,13 +74,14 @@ class Script(scripts.Script):
             else:
                 proc.images[0] = write_on_image(proc.images[0], "full prompt")
 
-            images.save_image(proc.images[0], p.outpath_samples, "", proc.seed, proc.prompt, opts.samples_format, info= proc.info, p=p)
+            if opts.samples_save:
+                images.save_image(proc.images[0], p.outpath_samples, "", proc.seed, proc.prompt, opts.samples_format, info= proc.info, p=p)
 
         unwanted_grid_because_of_img_count = len(proc.images) < 2 and opts.grid_only_if_multiple
         if ((opts.return_grid or opts.grid_save) and not p.do_not_save_grid and not unwanted_grid_because_of_img_count) or always_grid:
             grid = images.image_grid(proc.images)
             proc.images.insert(0,grid)
             proc.infotexts.insert(0, proc.infotexts[-1])
-            if opts.grid_save or always_grid:
+            if opts.grid_save:
                 images.save_image(grid, p.outpath_grids, "grid", initial_seed, initial_prompt, opts.grid_format, info=proc.info, short_filename=not opts.grid_extended_filename, p=p, grid=True)
         return proc


### PR DESCRIPTION
Currently, the script totally disregards the flags `opts.samples_save` and `opts.grid_save` ("Always save all generated images" and "Always save all generated image grids" in global settings respectively)

(Well—"totally disregards" is not quite correct for the latter: It currently effectively treats `opts.grid_save` as an alternative to the scripts own `always_grid`; either can be set to produce a grid. In which cases it saves the grid anyway, even if `opts.grid_save` is false. This does not seem like intended behaviour.)

After this fix, the expected behavior should now be:
 - Individual samples are produced in all cases (as before), but are only saved if `opts.samples_save` is true.
 - Grids are *produced* if either `opts.grid_save` or `always_grid` are true (as before), but are only saved if `opts.grid_save` is true.